### PR TITLE
Upgrade dependency

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -68,6 +68,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
+		<version>1.1.10.5</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Upgrade org.xerial.snappy:snappy-java@1.1.8.4 to version 1.1.10.5